### PR TITLE
fix: rbac permissions for controller

### DIFF
--- a/controllers/nifi/nifi_controller.go
+++ b/controllers/nifi/nifi_controller.go
@@ -87,11 +87,15 @@ func (r *Reconciler) reconcileResources(ctx context.Context, req ctrl.Request, n
 }
 
 // Reconcile loop function
-//+kubebuilder:rbac:groups=bigdata.quay.io,resources=nifi,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=bigdata.quay.io,resources=nifi/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=bigdata.quay.io,resources=nifi/finalizers,verbs=update
+//+kubebuilder:rbac:groups=bigdata.quay.io,resources=nifis,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=bigdata.quay.io,resources=nifis/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=bigdata.quay.io,resources=nifis/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;delete
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	rlog := ctrllog.FromContext(ctx, "namespace", req.Namespace, "name", req.Name)
 	rlog.Info("Reconciling Nifi instance")


### PR DESCRIPTION
Fixed RBAC permissions for multiple resources: services, configmaps, statefulsets, nifis

Fixes the following issues:
```
cannot list/create/delete resource "configmaps" in API group "" at the cluster scope
cannot list/create/delete resource "services" in API group "" at the cluster scope
cannot list/create/delete resource "statefulsets" in API group "" at the cluster scope
cannot list resource "nifis" in API group "bigdata.quay.io" at the cluster scope
```
